### PR TITLE
Fix: Backspace and key event browser support

### DIFF
--- a/src/TagsInput.vue
+++ b/src/TagsInput.vue
@@ -13,11 +13,11 @@
             <input type="text"
                 :placeholder="placeholder"
                 v-model="input"
-                @keypress.enter.prevent="tagFromInput"
-                @keypress.backspace="removeLastTag"
-                @keypress.down="nextSearchResult"
-                @keypress.up="prevSearchResult"
-                @keypress.esc="ignoreSearchResults"
+                @keyup.enter.prevent="tagFromInput"
+                @keydown.delete="removeLastTag"
+                @keydown.down="nextSearchResult"
+                @keydown.up="prevSearchResult"
+                @keyup.esc="ignoreSearchResults"
                 @keyup="searchTag"
                 @value="tags">
 


### PR DESCRIPTION
Great work on the plugin, it's really good.

This pull request should fix the backspace problem, since Vue actually uses the `.delete` modifier, not `.backspace`.
https://vuejs.org/v2/guide/events.html#Key-Modifiers

It should also make the key events work in Chrome and Edge. I was having problems there until I changed from `keypress` to `keyup` and `keydown`.

I set the arrows keys to `keydown` so that you can just hold it down to scroll through available tags fast. Same with the delete key, if you want to delete all tags by just holding down backspace, instead och clicking several times. They still just trigger once if you don't hold it down. :)