### PR TITLE
Add a validate function prop

### DIFF
--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -104,6 +104,11 @@ export default {
             type: Boolean,
             default: false
         },
+        
+        validate: {
+            type: Function,
+            default: () => true
+        }
     },
 
     data() {
@@ -181,7 +186,7 @@ export default {
 
         addTag(slug, text) {
             // Check if the limit has been reached
-            if (this.limit > 0 && this.tags.length >= this.limit) {
+            if (this.limit > 0 && this.tags.length >= this.limit && ! this.validate(text)) {
                 return false;
             }
 


### PR DESCRIPTION
This will allow a user to pass a function that will be called to validate the text before it is added as a tag. Common use case can be a list of emails, that you want to validate an item is a valid email, but can be useful for many things.