### PR TITLE
Fixed dark theme bug

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -100,3 +100,7 @@
 .tags-input input:focus {
     outline: none;
 }
+
+.tags-input input[type="text"] {
+    color: #495057;
+}


### PR DESCRIPTION
If you have a dark theme (for instance, I'm using GNOME + Adwaita Dark), the input would not be visible since it uses white as the default input color and the background is white too. Note: the color was taken from the `.form-control` bootstrap class