### PR TITLE
Fix key in Vue init

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you're not using NPM, you can include the required files into your page manua
 <script>
     new Vue({
         el: '#app',
-        components: { VoerroTagsInput },
+        components: { "tags-input": VoerroTagsInput },
     });
 </script>
 ```


### PR DESCRIPTION
The custom element "tags-input", as used below, can only be accessed if we declare its name accordingly.

_(I have no idea why GitHub thinks I changed the last line)_