### PR TITLE
dropdownFix

### DIFF
--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -49,7 +49,7 @@
             <ul v-else-if="typeaheadStyle === 'dropdown'" :class="`typeahead-${typeaheadStyle}`">
                 <li v-for="(tag, index) in searchResults"
                 :key="index"
-                v-html="tag.text"
+                v-html="tag.value"
                 @mouseover="searchSelection = index"
                 @mousedown.prevent="tagFromSearchOnClick(tag)"
                 v-bind:class="{


### PR DESCRIPTION
Hi, the fields of existing tags are not showing on the dropdown because of this simple issue, which is visible in your own demo, if you choose the dropdown option.

https://voerro.github.io/vue-tagsinput/
