### PR TITLE
Additional Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Event | Description
 @keyup | Fires on a keyup event
 @focus | Fired when the input is focused
 @blur | Fired when the input is blurred
+@change | Fired when the input text changes
 
 ```html
 <voerro-tags-input
@@ -183,6 +184,7 @@ Event | Description
     @keyup="onKeyUp"
     @focus="onFocus"
     @blur="onBlur"
+    @change="onChange"
 ></voerro-tags-input>
 ```
 
@@ -227,6 +229,10 @@ new Vue({
         onBlur() {
             console.log('Input blurred');
         },
+
+        onChange(value) {
+            console.log(`Input changed: ${value}`);
+        }
     }
 });
 </script>

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ typeahead-style | String | 'badges' | The autocomplete prompt style. Possible va
 typeahead-max-results | Number | 0 | Maximum number of typeahead results to be shown. 0 - unlimited.
 typeahead-activation-threshold | Number | 1 | Show typeahead results only after at least this many characters were entered. When set to 0, typeahead with all the available tags will be displayed on input focus.
 typeahead-always-show | Boolean | false | Always show typeahead, even if not focused or under typeahead-activation-threshold.
+typeahead-hide-discard | Boolean | false | Hides the 'Discard Search Results' option.
 placeholder | String | 'Add a tag' | The placeholder of the tag input.
 limit | Number | 0 | Limit the number of tags that can be chosen. 0 = no limit.
 only-existing-tags | Boolean | false | Only existing tags can be added/chosen. New tags won't be created.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ delete-on-backspace | Boolean | true | Whether deleting tags by pressing Backspa
 allow-duplicates | Boolean | false | Allow users to add the same tags multiple times.
 validate | Function | `text => true` | Callback to validate tags' text with.
 add-tags-on-comma | Boolean | false | Add new tags when comma is pressed. The search (typeahead) results are ignored.
+add-tags-on-space | Boolean | false | Add new tags when space is pressed. The search (typeahead) results are ignored.
 add-tags-on-blur | Boolean | false | Add new tags when on the input is blur. The search (typeahead) results are ignored.
 sort-search-results | Boolean | true | Whether the search results should be sorted.
 before-adding-tag | Function | `tag => true` | Callback to perform additional checks and actions before a tag is added. Return `true` to allow a tag to be added or `false` to forbid the action.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ typeahead | Boolean | false | Whether the typeahead (autocomplete) functionality
 typeahead-style | String | 'badges' | The autocomplete prompt style. Possible values: `badges`, `dropdown`.
 typeahead-max-results | Number | 0 | Maximum number of typeahead results to be shown. 0 - unlimited.
 typeahead-activation-threshold | Number | 1 | Show typeahead results only after at least this many characters were entered. When set to 0, typeahead with all the available tags will be displayed on input focus.
+typeahead-always-show | Boolean | false | Always show typeahead, even if not focused or under typeahead-activation-threshold.
 placeholder | String | 'Add a tag' | The placeholder of the tag input.
 limit | Number | 0 | Limit the number of tags that can be chosen. 0 = no limit.
 only-existing-tags | Boolean | false | Only existing tags can be added/chosen. New tags won't be created.

--- a/index.html
+++ b/index.html
@@ -58,6 +58,14 @@
                         </div>
                     </div>
 
+                    <div class="field">
+                      <div class="control">
+                        <label class="checkbox">
+                          <input type="checkbox" v-model="typeheadAlwaysShow">
+                          Always show Typeahead
+                        </label>
+                      </div>
+                    </div>
                     <div v-show="typeahead" style="margin-bottom: 1rem;">
                         <div class="field">
                             <label class="label">Typeahead Style</label>
@@ -165,6 +173,7 @@
                         :typeahead-style="typeaheadStyle"
                         :typeahead-max-results="typeaheadMaxResults"
                         :typeahead-activation-threshold="typeaheadActivationThreshold"
+                        :typeahead-always-show="typeheadAlwaysShow"
                         :placeholder="placeholder"
                         :limit="limit"
                         :only-existing-tags="onlyExistingTags"
@@ -229,6 +238,7 @@
                 addTagsOnBlur: false,
                 typeaheadMaxResults: 20,
                 typeaheadActivationThreshold: 1,
+                typeheadAlwaysShow: false,
                 eventLog: '',
             },
 

--- a/index.html
+++ b/index.html
@@ -167,6 +167,15 @@
                             </label>
                         </div>
                     </div>
+
+                    <div class="field">
+                        <div class="control">
+                            <label class="checkbox">
+                                <input type="checkbox" v-model="logChangeEvents">
+                                Log Change Events
+                            </label>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="column">
@@ -207,6 +216,7 @@
                         @tag-added="onTagAdded"
                         @tag-removed="onTagRemoved"
                         @tags-updated="onTagsUpdated"
+                        @change="onChange"
                     ></voerro-tags-input>
 
                     <hr>
@@ -262,6 +272,7 @@
                 typeaheadMaxResults: 20,
                 typeaheadActivationThreshold: 1,
                 typeheadAlwaysShow: false,
+                logChangeEvents: false,
                 eventLog: '',
             },
 
@@ -284,6 +295,12 @@
 
                 onTagsUpdated() {
                     this.logEvent('Tags updated\n');
+                },
+
+                onChange(evt) {
+                    if (this.logChangeEvents) {
+                        this.logEvent(`Changed ${JSON.stringify(evt)}\n`);
+                    }
                 },
             }
         });

--- a/index.html
+++ b/index.html
@@ -66,6 +66,16 @@
                         </label>
                       </div>
                     </div>
+
+                    <div class="field">
+                      <div class="control">
+                        <label class="checkbox">
+                          <input type="checkbox" v-model="typeaheadHideDiscard">
+                          Hide 'Discard Search Results' button
+                        </label>
+                      </div>
+                    </div>
+
                     <div v-show="typeahead" style="margin-bottom: 1rem;">
                         <div class="field">
                             <label class="label">Typeahead Style</label>
@@ -174,6 +184,7 @@
                         :typeahead-max-results="typeaheadMaxResults"
                         :typeahead-activation-threshold="typeaheadActivationThreshold"
                         :typeahead-always-show="typeheadAlwaysShow"
+                        :typeahead-hide-discard="typeaheadHideDiscard"
                         :placeholder="placeholder"
                         :limit="limit"
                         :only-existing-tags="onlyExistingTags"
@@ -236,6 +247,7 @@
                 allowDuplicates: false,
                 addTagsOnComma: false,
                 addTagsOnBlur: false,
+                typeaheadHideDiscard: false,
                 typeaheadMaxResults: 20,
                 typeaheadActivationThreshold: 1,
                 typeheadAlwaysShow: false,

--- a/index.html
+++ b/index.html
@@ -153,6 +153,15 @@
                     <div class="field">
                         <div class="control">
                             <label class="checkbox">
+                                <input type="checkbox" v-model="addTagsOnSpace"> 
+                                Add Tags on Space
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="field">
+                        <div class="control">
+                            <label class="checkbox">
                                 <input type="checkbox" v-model="addTagsOnBlur"> 
                                 Add Tags on Blur
                             </label>
@@ -192,6 +201,7 @@
                         :delete-on-backspace="deleteOnBackspace"
                         :allow-duplicates="allowDuplicates"
                         :add-tags-on-comma="addTagsOnComma"
+                        :add-tags-on-space="addTagsOnSpace"
                         :add-tags-on-blur="addTagsOnBlur"
                         @initialized="onInitialized"
                         @tag-added="onTagAdded"
@@ -246,6 +256,7 @@
                 deleteOnBackspace: true,
                 allowDuplicates: false,
                 addTagsOnComma: false,
+                addTagsOnSpace: false,
                 addTagsOnBlur: false,
                 typeaheadHideDiscard: false,
                 typeaheadMaxResults: 20,

--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -34,7 +34,7 @@
         <!-- Typeahead/Autocomplete -->
         <div v-show="searchResults.length">
             <p v-if="typeaheadStyle === 'badges'" :class="`typeahead-${typeaheadStyle}`">
-                <span class="tags-input-badge typeahead-hide-btn tags-input-typeahead-item-default"
+                <span v-if="!typeaheadHideDiscard" class="tags-input-badge typeahead-hide-btn tags-input-typeahead-item-default"
                     @click.prevent="clearSearchResults">Discard Search Results</span>
 
                 <span v-for="(tag, index) in searchResults"
@@ -50,7 +50,7 @@
             </p>
 
             <ul v-else-if="typeaheadStyle === 'dropdown'" :class="`typeahead-${typeaheadStyle}`">
-                <li class="tags-input-typeahead-item-default typeahead-hide-btn"
+                <li v-if="!typeaheadHideDiscard" class="tags-input-typeahead-item-default typeahead-hide-btn"
                     @mousedown.prevent="clearSearchResults">Discard search results</li>
 
                 <li v-for="(tag, index) in searchResults"
@@ -110,6 +110,12 @@ export default {
             type: Boolean,
             default: false
         },
+
+        typeaheadHideDiscard: {
+            type: Boolean,
+            default: false
+        },
+
         placeholder: {
             type: String,
             default: 'Add a tag'

--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -106,6 +106,10 @@ export default {
             default: 0
         },
 
+        typeaheadAlwaysShow: {
+            type: Boolean,
+            default: false
+        },
         placeholder: {
             type: String,
             default: 'Add a tag'
@@ -190,7 +194,9 @@ export default {
 
     created () {
         this.tagsFromValue();
-
+        if (this.typeaheadAlwaysShow) {
+            this.searchTag(false);
+        }
         // Emit an event
         this.$emit('initialized');
     },
@@ -226,7 +232,15 @@ export default {
 
         value() {
             this.tagsFromValue();
-        }
+        },
+
+        typeaheadAlwaysShow(newValue) {
+            if (newValue) {
+                this.searchTag(false);
+            } else {
+                this.clearSearchResults();
+            }
+        },
     },
 
     methods: {
@@ -394,12 +408,12 @@ export default {
                 return false;
             }
 
-            if (this.oldInput != this.input || (!this.searchResults.length && this.typeaheadActivationThreshold == 0)) {
+            if (this.oldInput != this.input || (!this.searchResults.length && this.typeaheadActivationThreshold == 0) || this.typeaheadAlwaysShow) {
                 this.searchResults = [];
                 this.searchSelection = 0;
                 let input = this.input.trim();
 
-                if ((input.length && input.length >= this.typeaheadActivationThreshold) || this.typeaheadActivationThreshold == 0) {
+                if ((input.length && input.length >= this.typeaheadActivationThreshold) || this.typeaheadActivationThreshold == 0 || this.typeaheadAlwaysShow) {
                     // Find all the existing tags which include the search text
                     const searchQuery = this.escapeRegExp(
                         this.caseSensitiveTags ? input : input.toLowerCase()
@@ -603,8 +617,9 @@ export default {
                 // Add the inputed tag
                 this.tagFromInput(true);
             }
-
-            this.hideTypeahead();
+            if (!this.typeaheadAlwaysShow) {
+                this.hideTypeahead();
+            }
         },
     }
 }

--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -151,6 +151,11 @@ export default {
             default: false
         },
 
+        addTagsOnSpace: {
+            type: Boolean,
+            default: false
+        },
+
         addTagsOnBlur: {
             type: Boolean,
             default: false
@@ -213,6 +218,16 @@ export default {
 
             if (newVal.length && newVal != oldVal) {
                 const diff = newVal.substring(oldVal.length, newVal.length);
+
+                if (this.addTagsOnSpace) {
+                    if (newVal.endsWith(' ')) {
+                        // The space shouldn't actually be inserted
+                        this.input = newVal.trim();
+
+                        // Add the inputed tag
+                        this.tagFromInput(true);
+                    }
+                }
 
                 if (this.addTagsOnComma) {
                     newVal = newVal.trim();

--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -240,6 +240,8 @@ export default {
                         this.tagFromInput(true);
                     }
                 }
+
+                this.$emit('change', newVal);
             }
         },
 
@@ -591,6 +593,15 @@ export default {
             }
 
             return false;
+        },
+
+        /**
+         * Clear the input.
+         * 
+         * @returns void
+         */
+        clearInput() {
+            this.input = '';
         },
 
         /**

--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -418,6 +418,9 @@ export default {
             this.$nextTick(() => {
                 this.$emit('tag-removed', tag);
                 this.$emit('tags-updated');
+                if (this.typeaheadAlwaysShow) {
+                    this.searchTag();
+                }
             });
         },
 
@@ -518,6 +521,11 @@ export default {
         clearSearchResults() {
             this.searchResults = [];
             this.searchSelection = 0;
+            if (this.typeaheadAlwaysShow) {
+                this.$nextTick(() => {
+                    this.searchTag();
+                });
+            }
         },
 
         /**
@@ -651,6 +659,8 @@ export default {
             }
             if (!this.typeaheadAlwaysShow) {
                 this.hideTypeahead();
+            } else {
+                this.searchTag();
             }
         },
     }


### PR DESCRIPTION
Added a few features:

`type-ahead-always-show` will show the type ahead regardless of focus or typeahead-max-threshold (fixes #70)

`typeahead-hide-discard` will hide the 'Discard Search Results' button (useful when paired with `type-ahead-always-show` above)

`add-tags-on-space` will add tags when a user hits the space key (mirrored from `add-tags-on-comma`) (fixes #63)

@change event fires when the input changes (fixes #73). 

Added a method to clear the input (use case would be parsing pasted information). Example:  pasting in multiple tags separated by commas or spaces, you would want capture the input with onChange, update the tag array manually after parsing for tags, and then clear the input.

README and example index.html file updated