### PR TITLE
Update to Inline Style

### DIFF
--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -67,7 +67,7 @@
             </ul>
         </div>
     </div>
-</template>false
+</template>
 
 <script>
 export default {

--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="tags-input-root">
+    <div class="tags-input-root" style="position: relative;">
         <div :class="wrapperClass + ' tags-input'">
             <span class="tags-input-badge tags-input-badge-pill tags-input-badge-selected-default"
                 v-for="(tag, index) in tags"
@@ -67,7 +67,7 @@
             </ul>
         </div>
     </div>
-</template>
+</template>false
 
 <script>
 export default {
@@ -678,9 +678,3 @@ export default {
     }
 }
 </script>
-
-<style>
-.tags-input-root {
-    position: relative;
-}
-</style>


### PR DESCRIPTION
Update in order to Fix Code Splitting Issue with Laravel Mix, Laravael Mix has an issue with Styles when code-splitting, this is a Webpack related Issue, Having Inline Styles creates a situation where the component loads sometimes after compilation and does not most times. Inlining the styles and removing the Style tag from the component, Fixes the issue.