### PR TITLE
Consistent component naming in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you're not using NPM, you can include the required files into your page manua
 <script>
     new Vue({
         el: '#app',
-        components: { "v-tags-input": VoerroTagsInput },
+        components: { "tags-input": VoerroTagsInput },
     });
 </script>
 ```


### PR DESCRIPTION
The loading example calls the component `v-tags-input` but all other references in the readme use `tags-input`.