### PR TITLE
Allow customizing selected tags

### DIFF
--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -8,8 +8,9 @@
                 v-for="(tag, index) in tags"
                 :key="index"
             >
-                <span v-html="tag.value"></span>
-
+                <slot name="tag" :tag="tag" :index="index">
+                    <span v-html="tag.value"></span>
+                </slot>
                 <a href="#"
                     class="tags-input-remove"
                     @click.prevent="removeTag(index)"></a>

--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -8,12 +8,12 @@
                 v-for="(tag, index) in tags"
                 :key="index"
             >
-                <slot name="tag" :tag="tag" :index="index">
+                <slot name="tag" :tag="tag" :index="index" :removeTag="removeTag">
                     <span v-html="tag.value"></span>
+                    <a href="#"
+                        class="tags-input-remove"
+                        @click.prevent="removeTag(index)"></a>
                 </slot>
-                <a href="#"
-                    class="tags-input-remove"
-                    @click.prevent="removeTag(index)"></a>
             </span>
 
             <input type="text"

--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -8,7 +8,7 @@
                 v-for="(tag, index) in tags"
                 :key="index"
             >
-                <slot name="tag" :tag="tag" :index="index" :removeTag="removeTag">
+                <slot name="selected-tag" :tag="tag" :index="index" :removeTag="removeTag">
                     <span v-html="tag.value"></span>
                     <a href="#"
                         class="tags-input-remove"


### PR DESCRIPTION
Adds a `<slot>` that wraps selected tags. Doesn't break any existing behavior.

<details><summary>Component code example</summary>

```vue
<template>
    <tags-input
            :typeahead="true"
            :existing-tags="existingTags"
            :typeahead-hide-discard="true"
            :only-existing-tags="true"
            :typeahead-activation-threshold="0"
            class="root"
    >
        <template v-slot:selected-tag="{tag, index, removeTag}">
            &lt;<span class="custom-tag" v-html="tag.value" @click="removeTag"></span>&gt;
        </template>
    </tags-input>
</template>

<script>
    import VoerroTagsInput from '@voerro/vue-tagsinput';

    export default {
        name: "CustomTagsInput",
        data() {
            return {
                existingTags:
                    [
                        {text: 'Hello', value: 'hello'},
                        {text: 'Hola', value: 'hola'},
                        {text: 'Fork', value: 'fork'},
                        {text: 'Spork', value: 'spork'},
                        {text: 'Some dude', value: 'somedude'},
                    ]
            };
        },
        components: {
            'tags-input': VoerroTagsInput,
        }
    }
</script>

<style scoped>
    @import "~@voerro/vue-tagsinput/dist/style.css";

    .root >>> .tags-input-badge-pill {
        padding-right: 0;
        padding-left: 0;
        border-radius: 0;
    }

    .root >>> .tags-input-badge-selected-default {
        background-color: transparent;
    }

    .root >>> .tags-input span  {
        margin: 0;
    }

    .root >>> .tags-input input[type="text"] {
        display: inline;
        width: 2em;
    }

    .root >>> .tags-input .custom-tag {
        padding: .3em;
        background-color: #d4a1bb;
    }

</style>

```

</details>

Result:

![](https://i.imgur.com/psZi85K.png)
Unlike https://github.com/voerro/vue-tagsinput/pull/89 it allows more customization

Ideally, this should be expanded to allow customizing typeahead tags, but I think that requires some breaking changes:

- HTML should be reorganized so styles are not applied to the `v-for` subjects, probably `<template v-for>` should be used to not add extra wrapper elements;
- All tag styling should be applied to slot content, not to slot wrapper.

This would break existing CSS that customizes tags, so this is a proposal for a major version.