### PR TITLE
Not enter a tag if IME is running

### DIFF
--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -29,6 +29,8 @@
                 :placeholder="placeholder"
                 v-model="input"
                 v-show="!hideInputField"
+                @compositionstart="composing=true"
+                @compositionend="composing=false"
                 @keydown.enter.prevent="tagFromInput(false)"
                 @keydown.8="removeLastTag"
                 @keydown.down="nextSearchResult"
@@ -269,6 +271,7 @@ export default {
             selectedTag: -1,
 
             isActive: false,
+            composing: false,
         };
     },
 
@@ -380,6 +383,8 @@ export default {
          * @returns void
          */
         tagFromInput(ignoreSearchResults = false) {
+            if (this.composing) return;
+
             // If we're choosing a tag from the search results
             if (this.searchResults.length && this.searchSelection >= 0 && !ignoreSearchResults) {
                 this.tagFromSearch(this.searchResults[this.searchSelection]);


### PR DESCRIPTION
Not enter a tag if IME is running

# Fix

## before

selected a tag when key down enter even if IME is running

![before](https://user-images.githubusercontent.com/1284368/105980935-d3599d00-60d8-11eb-8c6b-738e131868cb.gif)

## after

Not select a tag when key down enter if IME is running

![after](https://user-images.githubusercontent.com/1284368/105980941-d5236080-60d8-11eb-974d-8e772aa523b2.gif)


## ref
https://developer.mozilla.org/en-US/docs/Mozilla/IME_handling_guide