### PR TITLE
Fixed duplicate results when using AJAX

### DIFF
--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -590,8 +590,9 @@ export default {
                 const compareable = this.caseSensitiveTags
                     ? tag[this.textField]
                     : tag[this.textField].toLowerCase();
+                const keys = this.searchResults.map((res) => (res.key));
 
-                if (compareable.search(searchQuery) > -1 && ! this.tagSelected(tag)) {
+                if (compareable.search(searchQuery) > -1 && ! this.tagSelected(tag) && ! keys.includes(tag.key)) {
                     this.searchResults.push(tag);
                 }
             }


### PR DESCRIPTION
AJAX calls added multiple tags because the AJAX success handler was called on every keystroke. 

With this PR there is a check on every keystroke if the tag isn't already displayed in the searchResults.