### PR TITLE
fix: catch undefined window

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 import VoerroTagsInput from './VoerroTagsInput.vue'
 
-window.VoerroTagsInput = VoerroTagsInput;
+if (typeof window !== 'undefined') {
+    window.VoerroTagsInput = VoerroTagsInput;
+}
 
 export default VoerroTagsInput;


### PR DESCRIPTION
When rendering the component on the server, the window object is not defined.