### PR TITLE
Revert #114 (causes side effects)

### DIFF
--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -354,8 +354,6 @@ export default {
             this.typeaheadTags.splice(0);
 
             this.typeaheadTags = this.cloneArray(newVal);
-
-            this.searchTag();
         },
 
         tags() {


### PR DESCRIPTION
Revert PR #114 as this can now be done using `typeahead-callback` without causing any weird side effects.

Example of a side-effect is: if `typeahead-activation-threshold` is set to 0 and you update the existing-tags then it will open the dropdown.